### PR TITLE
Changes on the VIC-IV branch from me

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,13 +44,14 @@ matrix:
         - set +e
         - ps auxwwww || true
         - uptime
+        - build/show-git-info
       script:
         - set -e
-        - make -j 2 RELEASE=yes
+        - make -j 2 RELEASE=yes OFFICIALBUILD=yes
         - set +e
         - for a in build/bin/*.native ; do strip $a ; ls -l $a ; done
         - set -e
-        - make RELEASE=yes deb
+        - make RELEASE=yes OFFICIALBUILD=yes deb
         - set +e
         - cp build/bin/*.deb build/bin/*.rpm . || true
         - build/bin/xmega65.native --help || true
@@ -72,9 +73,12 @@ matrix:
         on:
           branch:
             - master
+            - next
             - dev
             - vic
             - hmw
+      after_deploy:
+            - build/deploy/discord-webhook.sh success "Ubuntu Linux DEB" ANY:DISCORD_XEMU_SERVER_TEST_CHANNEL_WEBHOOK master,hmw,next:DISCORD_MEGA65_SERVER_XEMU_CHANNEL_WEBHOOK || true
     - name: Windows cross-compilation on Linux
       os: linux
       addons:
@@ -85,6 +89,7 @@ matrix:
             - binutils-mingw-w64-x86-64
             - bzip2
             - coreutils
+            - curl
             - file
             - gawk
             - gcc-mingw-w64-i686
@@ -105,22 +110,23 @@ matrix:
         - set +e
         - ps auxwwww || true
         - uptime
+        - build/show-git-info
       script:
         - set -e
-        - make -j 2 ARCH=win64 RELEASE=yes
+        - make -j 2 ARCH=win64 RELEASE=yes OFFICIALBUILD=yes
         - set +e
         - for a in build/bin/*.win64 ; do x86_64-w64-mingw32-strip $a ; ls -l $a ; done
-        - cp README.md LICENSE `x86_64-w64-mingw32-sdl2-config --prefix`/bin/*.dll build/bin/
-        - build/zipper.sh build/bin xemu-binaries-win64.zip build/bin/*.dll build/bin/*.win64 README.md LICENSE
+        - cp README.md LICENSE AUTHORS `x86_64-w64-mingw32-sdl2-config --prefix`/bin/*.dll build/bin/
+        - build/zipper.sh build/bin xemu-binaries-win64.zip build/bin/*.dll build/bin/*.win64 README.md LICENSE AUTHORS
         - cp build/bin/xemu-binaries-win64.zip .
         - build/nsi-build-native.sh win64 `build/system-config win64 sdl2 dll` || true
         - cp build/bin/install-xemu-win64.exe . || true
         - set -e
-        - make -j 2 ARCH=win32 RELEASE=yes
+        - make -j 2 ARCH=win32 RELEASE=yes OFFICIALBUILD=yes
         - set +e
         - for a in build/bin/*.win32 ; do i686-w64-mingw32-strip $a ; ls -l $a ; done
-        - cp README.md LICENSE `i686-w64-mingw32-sdl2-config --prefix`/bin/*.dll build/bin/
-        - build/zipper.sh build/bin xemu-binaries-win32.zip build/bin/*.dll build/bin/*.win32 README.md LICENSE
+        - cp README.md LICENSE AUTHORS `i686-w64-mingw32-sdl2-config --prefix`/bin/*.dll build/bin/
+        - build/zipper.sh build/bin xemu-binaries-win32.zip build/bin/*.dll build/bin/*.win32 README.md LICENSE AUTHORS
         - cp build/bin/xemu-binaries-win32.zip .
         - build/nsi-build-native.sh win32 `build/system-config win32 sdl2 dll` || true
         - cp build/bin/install-xemu-win32.exe . || true
@@ -141,9 +147,12 @@ matrix:
         on:
           branch:
             - master
+            - next
             - dev
             - vic
             - hmw
+      after_deploy:
+            - build/deploy/discord-webhook.sh success "Windows" ANY:DISCORD_XEMU_SERVER_TEST_CHANNEL_WEBHOOK master,hmw,next:DISCORD_MEGA65_SERVER_XEMU_CHANNEL_WEBHOOK || true
     - name: MacOS native compilation
       os: osx
       osx_image: xcode11
@@ -162,14 +171,15 @@ matrix:
         - set +e
         - ps auxwwww || true
         - uptime
+        - build/show-git-info
       script:
         - set -e
-        - make -j 2 RELEASE=yes
+        - make -j 2 RELEASE=yes OFFICIALBUILD=yes
         - set +e
         - for a in build/bin/*.native ; do build/mangle_dylib_osx.sh $a ; strip $a ; done
         - build/bin/xmega65.native --help || true
-        - cp README.md LICENSE build/bin/
-        - build/zipper.sh build/bin xemu-binaries-osx.zip build/bin/*.dylib build/bin/*.native README.md LICENSE
+        - cp README.md LICENSE AUTHORS build/bin/
+        - build/zipper.sh build/bin xemu-binaries-osx.zip build/bin/*.dylib build/bin/*.native README.md LICENSE AUTHORS
         - cp build/bin/xemu-binaries-osx.zip .
         - uptime ; pwd ; ls -l
       before_deploy:
@@ -189,9 +199,13 @@ matrix:
         on:
           branch:
             - master
+            - next
             - dev
             - vic
             - hmw
+            - discord
+      after_deploy:
+            - build/deploy/discord-webhook.sh success "MacOS(x86)" ANY:DISCORD_XEMU_SERVER_TEST_CHANNEL_WEBHOOK master,hmw,next:DISCORD_MEGA65_SERVER_XEMU_CHANNEL_WEBHOOK || true
 
 env:
   global:

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,23 @@
+X-Emulators - aka "Xemu" - (C)2016-2021 LGB Gábor Lénárt lgblgblgb@gmail.com
+
+[ Xemu is licensed under the terms of GNU/GPL v2, for more information please read file LICENSE ]
+
+Major direct contributors of the project:
+
+  * Hernán Di Pietro <hernan.di.pietro@gmail.com> (major works: MacOS GUI code, MEGA65 VIC-IV refinements)
+
+Other than my (or "our", see about contributors) own work, Xemu uses:
+
+  * SDL2 (externally linked, not in Xemu, but it's always nice to give the credit)
+  * Heavily modified (by me) Z80ex, original project: https://sourceforge.net/projects/z80ex/
+  * Modified version of "WebSid" which seems to be from "TinySID for Linux": https://github.com/wothke/websid
+  * LodePNG: https://lodev.org/lodepng/
+  * Nuked-OPL3: https://github.com/nukeykt/Nuked-OPL3
+
+Help from other people (maybe not a full list, sorry about that), I would like to thank:
+
+  * Paul Gardner-Stephen: for tons of help on answering my questions and problems with Commodore 65 and MEGA65,
+    so I could start to emulate them (and also for creating GS65/MEGA65 at all, btw)
+  * Hernán Di Pietro: other than being a direct contributor, also helped in testing Xemu, sharing his
+    opinion and suggestions, and things like these
+  * Snoopy on Forum64: for many tests (C65/MEGA65), bug reports

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,10 @@ ARCH	= native
 all:
 	for t in $(TARGETS) ; do $(MAKE) -C targets/$$t RELEASE=$(RELEASE) || exit 1 ; done
 
+install:
+	$(MAKE) all
+	for t in $(TARGETS) ; do $(MAKE) -C targets/$$t RELEASE=$(RELEASE) install || exit 1 ; done
+
 all-arch:
 	for t in $(TARGETS) ; do for a in $(ARCHS) ; do $(MAKE) -C targets/$$t ARCH=$$a RELEASE=$(RELEASE) || exit 1 ; done ; done
 
@@ -90,4 +94,4 @@ doxypublish:
 config:
 	ARCH=$(ARCH) $(MAKE) -C build/configure
 
-.PHONY: all all-arch clean all-clean roms distclean dep all-dep deb nsi publish doxygen doxypublish config
+.PHONY: all all-arch clean all-clean roms distclean dep all-dep deb nsi publish doxygen doxypublish config install

--- a/build/Makefile.common
+++ b/build/Makefile.common
@@ -1,7 +1,7 @@
-## Collection of *simple* emulators of some 8 bits machines using SDL2 library,
-## including the Commodore LCD and Commodore-65 and the MEGA65 too.
+## Collection of emulators of some 8 bits machines using SDL2 library,
+## including the Commodore LCD and Commodore 65 and the MEGA65 too.
 ##
-## Copyright (C)2016-2020 LGB (Gábor Lénárt) <lgblgblgb@gmail.com>
+## Copyright (C)2016-2021 LGB (Gábor Lénárt) <lgblgblgb@gmail.com>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -23,6 +23,8 @@ all:
 
 ARCH			= native
 TOPDIR			= ../..
+
+INSTALL_BINDIR		= /usr/local/bin
 
 $(TOPDIR)/build/configure/config-$(ARCH).h $(TOPDIR)/build/configure/config-$(ARCH).make:
 	if [ ! -s $(TOPDIR)/build/configure/config-$(ARCH).h -o ! -s $(TOPDIR)/build/configure/config-$(ARCH).make ]; then bash $(TOPDIR)/build/configure/configure --arch=$(ARCH) ; fi
@@ -57,6 +59,7 @@ OBJS			= $(TARGETOBJS) $(COMMONOBJS)
 ASMOUT			= no
 DEBUG			= no
 RELEASE			= no
+OFFICIALBUILD		= no
 
 CFLAGS_TARGET		= $(CFLAGS_TARGET_$(PRG_TARGET))
 LDFLAGS_TARGET		= $(LDFLAGS_TARGET_$(PRG_TARGET))
@@ -73,6 +76,9 @@ endif
 ifeq ($(RELEASE), yes)
 CFLAGS_OPT		+= $(CONFIG_CFLAGS_OPT_RELEASE) -DXEMU_RELEASE_BUILD
 CONFIG_CFLAGS_LINK	+= $(CONFIG_CFLAGS_OPT_RELEASE)
+endif
+ifeq ($(OFFICIALBUILD), yes)
+CFLAGS_OPT		+= -DXEMU_OFFICIAL_BUILD
 endif
 
 CFLAGS			= $(CONFIG_CFLAGS) $(CFLAGS_OPT) $(CFLAGS_TARGET) -I. -I$(TOPDIR) -include build/configure/config-$(ARCH).h
@@ -110,6 +116,7 @@ xemu-info:
 	@echo "Xemu-framework needed sources: $(SRCS_COMMON)"
 	@echo "Target-specific needed sources: $(SRCS_TARGET)"
 	@echo "Dependecy file created: $(DEPFILE)"
+	@echo "Executable: $(PRG)"
 
 $(TARGETOBJPREFIX)%.o: %.c $(DEPALL)
 ifeq ($(ASMOUT), yes)
@@ -126,7 +133,7 @@ endif
 $(PRG): $(OBJS) $(DEPALL)
 	@echo "const char *XEMU_BUILDINFO_ON  = \"`whoami`@`uname -n` on `uname -s` `uname -r`\";" > $(DEPFILEPREFIX)-buildinfo.c
 	@echo "const char *XEMU_BUILDINFO_AT  = \"`date`\";" >> $(DEPFILEPREFIX)-buildinfo.c
-	@echo "const char *XEMU_BUILDINFO_GIT = \"`git config --get remote.origin.url` `git rev-parse --abbrev-ref HEAD` `git rev-parse HEAD`\";" >> $(DEPFILEPREFIX)-buildinfo.c
+	@echo "const char *XEMU_BUILDINFO_GIT = \"`bash $(TOPDIR)/build/show-git-info`\";" >> $(DEPFILEPREFIX)-buildinfo.c
 	@echo "const char *XEMU_BUILDINFO_TARGET = \"$(PRG_TARGET) ($(PRG)) for $(TARGET) on \" XEMU_ARCH_NAME \" ($(ARCH)) using $(CONFIG_CC)\";" >> $(DEPFILEPREFIX)-buildinfo.c
 	@git log -1 --format=%cd --date=format:%Y%m%d%H%M%S > $(TOPDIR)/build/objs/cdate.data || date '+%Y%m%d%H%M%S' > $(TOPDIR)/build/objs/cdate.data
 	@echo "*** Commit date we're building ($(TOPDIR)/build/objs/cdate.data): `cat $(TOPDIR)/build/objs/cdate.data`"
@@ -138,7 +145,16 @@ run:	$(PRG)
 	cd $(TOPDIR) && XEMU_DEBUG_FILE=debug.log $(PRG_TOP_REL)
 
 strip: $(PRG)
-	$(STRIP) $(PRG)
+	$(CONFIG_STRIP) $(PRG)
+
+install:
+	@echo "Checking if target is UNIX ..."
+	test TARGET_IS_UNIX_$(TARGET_IS_UNIX) = TARGET_IS_UNIX_yes || exit 1
+	$(MAKE) $(PRG)
+	strip $(PRG)
+	mkdir -p $(INSTALL_BINDIR)
+	cp $(PRG) "$(INSTALL_BINDIR)/xemu-`basename $(PRG) .$(ARCH)`"
+	ls -l "$(INSTALL_BINDIR)/xemu-`basename $(PRG) .$(ARCH)`"
 
 dep:
 	rm -f $(DEPFILE)
@@ -151,7 +167,7 @@ $(DEPFILE): $(DEPALL) $(SRCS)
 clean:
 	rm -f $(TOPDIR)/build/objs/?-$(ARCH)-$(TARGET)-* $(PRG)
 
-.PHONY: clean all strip dep do-all run xemu-info config
+.PHONY: clean all strip dep do-all run xemu-info config install
 
 ifneq ($(wildcard $(DEPFILE)),)
 include $(DEPFILE)

--- a/build/configure/configure
+++ b/build/configure/configure
@@ -20,6 +20,8 @@
 
 echo "*** Running xemu-configure ***"
 
+MACOS_VERSION_MIN=10.6
+
 ###########################################################
 # Check some basic common UNIX utilities if work, we need #
 ###########################################################
@@ -139,6 +141,7 @@ done
 # Check "ARCH" and set _default_ values #
 #########################################
 
+STRIP_default=strip
 echo -n "Specified make ARCH to use: "
 if [ "$ARCH" = "native" ]; then
 	echo "$ARCH (intended for native target)"
@@ -150,16 +153,19 @@ elif [ "$ARCH" = "win32" ]; then
 	CC_default=i686-w64-mingw32-gcc
 	WINDRES_default=i686-w64-mingw32-windres
 	SDL2_CONFIG_default=i686-w64-mingw32-sdl2-config
+	STRIP_default=i686-w64-mingw32-strip
 elif [ "$ARCH" = "win64" ]; then
 	echo "$ARCH (intended for WIN64 cross-compilation on UNIX)"
 	CC_default=x86_64-w64-mingw32-gcc
 	WINDRES_default=x86_64-w64-mingw32-windres
 	SDL2_CONFIG_default=x86_64-w64-mingw32-sdl2-config
+	STRIP_default=x86_64-w64-mingw32-strip
 elif [ "$ARCH" = "html" ]; then
 	echo "$ARCH (intended for HTML/JS cross-compilation on UNIX)"
 	CC_default=emcc
 	WINDRES_default=
 	SDL2_CONFIG_default=internal
+	STRIP_default=strip-is-not-supported-for-this-arch
 elif [ "$ARCH" = "" ]; then
 	echo "UNSPECIFIED"
 	echo "Error, no ARCH variable passed to the $0 script. Do not forget to use the --arch=... parameter." >&2
@@ -310,6 +316,7 @@ fi
 echo "OK"
 
 echo "CONFIG_CC=$CC" >> $OUTPUT_MAKEFILE
+echo "CONFIG_STRIP=$STRIP_default" >> $OUTPUT_MAKEFILE
 
 ##############################
 # Test compiler flag support #
@@ -329,7 +336,8 @@ for a in \
 	            PIPE_SUPPORTED_BY_CC:-pipe: \
   		      O0_SUPPORTED_BY_CC:-O0: \
 		       G_SUPPORTED_BY_CC:-g: \
-		    FLTO_SUPPORTED_BY_CC:-flto
+		    FLTO_SUPPORTED_BY_CC:-flto \
+	     MACOSVERMIN_SUPPORTED_BY_CC:-mmacosx-version-min=$MACOS_VERSION_MIN
 do
 	b="`echo $a | cut -f1 -d:`"
 	c="`echo $a | cut -f2 -d:`"
@@ -392,16 +400,8 @@ fi
 if [ $FALIGN_FUNCTIONS_SUPPORTED_BY_CC = Y ]; then
 	CFLAGS_OPT="$CFLAGS_OPT-falign-functions=16 "
 fi
-echo "Common $CC flags to be used: $CFLAGS"
-echo "Common $CC optimization flags to be used: $CFLAGS_OPT"
-echo "Common $CC debug flags to be used: $CFLAGS_DEBUG"
-echo "CONFIG_CFLAGS=$CFLAGS" >> $OUTPUT_MAKEFILE
-echo "CONFIG_CFLAGS_OPT=$CFLAGS_OPT" >> $OUTPUT_MAKEFILE
-echo "CONFIG_CFLAGS_DEBUG=$CFLAGS_DEBUG" >> $OUTPUT_MAKEFILE
-echo "CONFIG_CFLAGS_LINK=$CFLAGS_LINK" >> $OUTPUT_MAKEFILE
-echo "CONFIG_CFLAGS_OPT_RELEASE=$CFLAGS_OPT_RELEASE" >> $OUTPUT_MAKEFILE
-echo "#define XEMU_MAKE_ARCH native" >> $OUTPUT_HEADERFILE
-echo "#define XEMU_MAKE_ARCH_NAME \"native\"" >> $OUTPUT_HEADERFILE
+echo "#define XEMU_MAKE_ARCH $ARCH" >> $OUTPUT_HEADERFILE
+echo "#define XEMU_MAKE_ARCH_NAME \"$ARCH\"" >> $OUTPUT_HEADERFILE
 echo "#define _CONFIG_DATE \"`date`\"" >> $OUTPUT_HEADERFILE
 echo "#define _CONFIG_OS \"`uname -a`\"" >> $OUTPUT_HEADERFILE
 
@@ -720,6 +720,14 @@ echo "XEMUGUI_CFLAGS=$XEMUGUI_CFLAGS" >> $OUTPUT_MAKEFILE
 echo "XEMUGUI_LIBS=$XEMUGUI_LIBS" >> $OUTPUT_MAKEFILE
 
 
+################
+# MACOS target #
+################
+
+if [ $TARGET_IS_OSX = Y -a $MACOSVERMIN_SUPPORTED_BY_CC = Y ]; then
+	CFLAGS="$CFLAGS-mmacosx-version-min=$MACOS_VERSION_MIN "
+fi
+
 #########################################
 # Windows target: check windres utility #
 #########################################
@@ -770,11 +778,32 @@ fi
 echo "MATH_LIBS=$MATH_LIBS" >> $OUTPUT_MAKEFILE
 echo "MATH_CFLAGS=" >> $OUTPUT_MAKEFILE
 
+########################################
+# Result of accumulated generic cflags #
+########################################
+
+echo "Common $CC flags to be used: $CFLAGS"
+echo "Common $CC optimization flags to be used: $CFLAGS_OPT"
+echo "Common $CC debug flags to be used: $CFLAGS_DEBUG"
+echo "CONFIG_CFLAGS=$CFLAGS" >> $OUTPUT_MAKEFILE
+echo "CONFIG_CFLAGS_OPT=$CFLAGS_OPT" >> $OUTPUT_MAKEFILE
+echo "CONFIG_CFLAGS_DEBUG=$CFLAGS_DEBUG" >> $OUTPUT_MAKEFILE
+echo "CONFIG_CFLAGS_LINK=$CFLAGS_LINK" >> $OUTPUT_MAKEFILE
+echo "CONFIG_CFLAGS_OPT_RELEASE=$CFLAGS_OPT_RELEASE" >> $OUTPUT_MAKEFILE
 
 ######################################################################## 
 # Must be the end of this script, do not put anything after this part! #
 ########################################################################
 
+if [ $TARGET_IS_UNIX = Y ]; then
+	echo "TARGET_IS_UNIX = yes" >> $OUTPUT_MAKEFILE
+fi
+if [ $TARGET_IS_WIN = Y ]; then
+	echo "TARGET_IS_WIN = yes" >> $OUTPUT_MAKEFILE
+fi
+if [ $TARGET_IS_OSX = Y ]; then
+	echo "TARGET_IS_OSX = yes" >> $OUTPUT_MAKEFILE
+fi
 
 cat >> $OUTPUT_HEADERFILE <<EOF
 #ifndef XEMU_NO_TARGET

--- a/build/deploy/discord-webhook.sh
+++ b/build/deploy/discord-webhook.sh
@@ -1,0 +1,201 @@
+#!/bin/bash
+# ------------------------------------------------------------------------------------------------------------------------------------------------
+# The original file has been downloaded from https://github.com/DiscordHooks/travis-ci-discord-webhook
+# Copyright: (C) 2017 Sankarsan Kampa, according to the MIT license: https://github.com/DiscordHooks/travis-ci-discord-webhook/blob/master/LICENSE
+# ------------------------------------------------------------------------------------------------------------------------------------------------
+# Also, this file has been HEAVILY modified by me for fitting to my needs in the Xemu project: (C)2021 Gabor Lenart (aka LGB)
+# ------------------------------------------------------------------------------------------------------------------------------------------------
+
+BOT_NAME="XEMU Builder"
+BOT_NAME_FUNNY="XEMU (body-)Builder"
+#BOT_AVATAR="https://travis-ci.org/images/logos/TravisCI-Mascot-1.png"
+BOT_AVATAR="https://lgblgblgb.github.io/xemu/images/xemu-48x48.png"
+AUTHOR_DISCORD_ID="731142195851034704"
+
+echo "[DISCORD] Starting ${BOT_NAME} discord trigger with parameter $1 in directory `pwd` on host `hostname`"
+
+cd `dirname $0`/../.. || exit 1
+XEMU_VERSION="$(cat build/objs/cdate.data)"
+if [ "$XEMU_VERSION" = "" ]; then
+	echo "[DISCORD] ERROR: no build cdate info? File: build/objs/cdate.data" >&2
+	exit 1
+fi
+
+echo "[DISCORD] XEMU version (cdate) is ${XEMU_VERSION}"
+
+case $1 in
+	"building" )
+		EMBED_COLOR=15105570
+		STATUS_MESSAGE="Building"
+		AVATAR="https://travis-ci.org/images/logos/TravisCI-Mascot-red.png"
+		;;
+
+	"success" )
+		EMBED_COLOR=3066993
+		STATUS_MESSAGE="Passed"
+		AVATAR="https://travis-ci.org/images/logos/TravisCI-Mascot-blue.png"
+		;;
+
+	"failure" )
+		EMBED_COLOR=15158332
+		STATUS_MESSAGE="Failed"
+		AVATAR="https://travis-ci.org/images/logos/TravisCI-Mascot-red.png"
+		;;
+
+	* )
+		EMBED_COLOR=0
+		STATUS_MESSAGE="Status Unknown"
+		AVATAR="https://travis-ci.org/images/logos/TravisCI-Mascot-1.png"
+		;;
+esac
+
+shift
+
+if [ $# -lt 1 ]; then
+	echo "[DISCORD] ERROR: Missing second parameter: build architecture" >&2
+	exit 1
+fi
+BUILD_ARCH="$1"
+
+shift
+
+if [ $# -lt 1 ]; then
+	echo "[DISCORD] ERROR: Missing branch(es):webhook-variable specification(s)" >&2
+	exit 1
+fi
+
+
+
+# ---------------------------------------------------------------------------------------------
+# Assume, this script is used on Travis
+# Use GITHUB workflows to get information instead, if available
+if [ "$TRAVIS_BRANCH" == "" -a "$GITHUB_REF" != "" ]; then
+	TRAVIS_BRANCH="$(echo $GITHUB_REF | awk -F/ '{ print $NF }')"
+	BUILDER_CI="Github"
+fi
+# If either of those, try to use local parameters
+if [ "$TRAVIS_COMMIT" == "" ]; then
+	TRAVIS_COMMIT="$(git log -1 --pretty="%H")"
+	if [ "$BUILDER_CI" == "" ]; then
+		BUILDER_CI="Unknown"
+	fi
+else
+	if [ "$BUILDER_CI" == "" ]; then
+		BUILDER_CI="Travis"
+	fi
+fi
+if [ "$TRAVIS_BRANCH" == "" ]; then
+	TRAVIS_BRANCH="$(git branch | awk 'BEGIN { s = "UNKNOWN" } $1 == "*" { s = $2 } END { print s }')"
+fi
+if [ "$TRAVIS_PULL_REQUEST" == "" ]; then
+	TRAVIS_PULL_REQUEST="false"
+fi
+if [ "$TRAVIS_REPO_SLUG" == "" ]; then
+	# Ehmm, kind of lame ...
+	TRAVIS_REPO_SLUG="$(git config --get remote.origin.url | egrep -o '[^/]+/[^/]+$' | sed 's/\.git$//')"
+fi
+# ---------------------------------------------------------------------------------------------
+XEMU_VERSION="$XEMU_VERSION/$TRAVIS_BRANCH"
+echo "[DISCORD] current branch is ${TRAVIS_BRANCH} commit is ${TRAVIS_COMMIT} XEMU version is ${XEMU_VERSION}"
+# ---------------------------------------------------------------------------------------------
+# End of madness
+
+
+AUTHOR_NAME="$(git log -1 "$TRAVIS_COMMIT" --pretty="%aN")"
+COMMITTER_NAME="$(git log -1 "$TRAVIS_COMMIT" --pretty="%cN")"
+COMMIT_SUBJECT="$(git log -1 "$TRAVIS_COMMIT" --pretty="%s")"
+COMMIT_MESSAGE="$(git log -1 "$TRAVIS_COMMIT" --pretty="%b")" | sed -E ':a;N;$!ba;s/\r{0,1}\n/\\n/g'
+
+if [ ${#COMMIT_SUBJECT} -gt 256 ]; then
+	COMMIT_SUBJECT="$(echo "$COMMIT_SUBJECT" | cut -c 1-253)"
+	COMMIT_SUBJECT+="..."
+fi
+
+if [ -n $COMMIT_MESSAGE ] && [ ${#COMMIT_MESSAGE} -gt 1900 ]; then
+	COMMIT_MESSAGE="$(echo "$COMMIT_MESSAGE" | cut -c 1-1900)"
+	COMMIT_MESSAGE+="..."
+fi
+
+if [ "$AUTHOR_NAME" == "$COMMITTER_NAME" ]; then
+	CREDITS="$AUTHOR_NAME authored & committed"
+else
+	CREDITS="$AUTHOR_NAME authored & $COMMITTER_NAME committed"
+fi
+
+if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+	URL="https://github.com/$TRAVIS_REPO_SLUG/pull/$TRAVIS_PULL_REQUEST"
+	echo "[DISCORD] No webhook activation for pull requests currently" >&2
+	exit 0
+else
+	URL=""
+fi
+
+
+TIMESTAMP=$(date -u +%FT%TZ)
+
+
+MSG=":desktop:  New Xemu build version **${XEMU_VERSION}** for **${BUILD_ARCH}** is now ***[on-line](<https://lgblgblgb.github.io/xemu/>)!***"
+# Branch based decisions
+MSG="${MSG} :scientist: "
+if [ "$TRAVIS_BRANCH" == "master" ]; then
+	MSG="${MSG}This is kind-of-**stable** (branch: **${TRAVIS_BRANCH}**) build, intended for _general use_."
+elif [ "$TRAVIS_BRANCH" == "next" ]; then
+	MSG="${MSG}This is next/**to-be-stable** with possible problems (branch: **${TRAVIS_BRANCH}**) build, so _you have been warned_, but you're more than welcome if you want to _help testing Xemu by using this branch_."
+elif [ "$TRAVIS_BRANCH" == "dev" ]; then
+	MSG="${MSG}This is **development** (branch: **${TRAVIS_BRANCH}**) build, it may ~~overclock your robot vacuum cleaner while trying to upgrade it into the Skynet~~ _won't work at all_."
+elif [ "$TRAVIS_BRANCH" == "hmw" ]; then
+	MSG="${MSG}This is **VIC-IV experimental** (branch: **${TRAVIS_BRANCH}**) build, it may ~~cause The Burn of all the VIC-IVs in the visible universe~~ _have problems, and lacks of other features of the other branches_."
+else
+	MSG="${MSG}This is \\\"**secret**\\\" not-for-general-use (branch: **${TRAVIS_BRANCH}**) build, ~~you don't want to even know about~~ _you want to be **extremely** careful with_."
+fi
+# Details about the build
+MSG="$MSG :zap: See git commit [**\`${TRAVIS_COMMIT:0:7}\`**](<https://github.com/${TRAVIS_REPO_SLUG}/commit/${TRAVIS_COMMIT}>)"
+if [ "$TRAVIS_JOB_WEB_URL" != "" ]; then
+	MSG="$MSG and the [build log](<${TRAVIS_JOB_WEB_URL}>)"
+fi
+MSG="${MSG}, built by ${BUILDER_CI}-CI"
+MSG="${MSG}. :calendar: _${BOT_NAME_FUNNY} on behalf of <@${AUTHOR_DISCORD_ID}> at ${TIMESTAMP}_"
+
+
+WEBHOOK_DATA='{ "username": "'$BOT_NAME'", "avatar_url": "'$BOT_AVATAR'", "content": "'$MSG'" }'
+
+#echo $WEBHOOK_DATA
+#exit 0
+
+USER_AGENT="TravisCI-Webhook"
+CONTENT_TYPE="Content-Type:application/json"
+X_AUTHOR="X-Author:Xemu"
+
+
+for ARG in $@ ; do
+	VALID_BRANCHES="$(echo "$ARG" | cut -d':' -f1)"
+	WEBHOOK_URL_VAR="$(echo "$ARG" | cut -d':' -f2)"
+	#echo "LGB allow-list=(${VALID_BRANCHES}) var-name=(${WEBHOOK_URL_VAR})"
+	if [ "$VALID_BRANCHES" == "" -o "$WEBHOOK_URL_VAR" == "" -o "$WEBHOOK_URL_VAR" == "$VALID_BRANCHES" ]; then
+		echo "[DISCORD] [${ARG}] ERROR: invalid specification for branch(es):webhook_url_var part. Skipping."
+		continue
+	fi
+	if [ "$VALID_BRANCHES" == "ANY" ]; then
+		echo "[DISCORD] [${ARG}] 'ANY' was specified for branch-list, treating as an always OK, not checking branch now."
+	else
+		if ! echo ",$VALID_BRANCHES," | grep -q ",$TRAVIS_BRANCH," ; then
+			echo "[DISCORD] [${ARG}] REJECT: This branch (${TRAVIS_BRANCH}) was not in the allow-list (${VALID_BRANCHES}) for this WEBHOOK (${WEBHOOK_URL_VAR})."
+			continue
+		fi
+		echo "[DISCORD] [${ARG}] branch (${TRAVIS_BRANCH}) was accepted according the allow-list (${VALID_BRANCHES})"
+	fi
+	echo "[DISCORD] [${ARG}] Triggering Discord's webhook ${WEBHOOK_URL_VAR} for branch ${TRAVIS_BRANCH} according to list of ${VALID_BRANCHES} ..."
+	# Dear reader! Surely, /etc/lgb/discord-webhooks.txt is on my own computer for testing :) So you can stop trying to spy on that somewhere :)
+	THE_URL="$(grep "^${WEBHOOK_URL_VAR}=" /etc/lgb/discord-webhooks.txt 2>/dev/null | tail -1 | cut -d'=' -f2-)"
+	if [ "$THE_URL" == "" ]; then
+		THE_URL="${!WEBHOOK_URL_VAR}"
+	fi
+	if [ "$THE_URL" != "" ]; then
+		( curl --fail --progress-bar -A "${USER_AGENT}" -H "${CONTENT_TYPE}" -H "${X_AUTHOR}" -d "${WEBHOOK_DATA}" "${THE_URL}" && echo "[DISCORD] [${ARG}] Successfully sent :-)" ) || echo "[DISCORD] [${ARG}] ERROR: Unable to send :-("
+	else
+		echo "[DISCORD] [${ARG}] ERROR: Variable ${WEBHOOK_URL_VAR} cannot be found"
+	fi
+	THE_URL=""
+done
+
+exit 0

--- a/build/show-git-info
+++ b/build/show-git-info
@@ -1,0 +1,49 @@
+#!/bin/bash
+## Part of the xemu project.
+## Copyright (C)2016-2021 LGB (Gábor Lénárt) <lgblgblgb@gmail.com>
+## ---
+## The problem: we need to get the GIT origin, including branch.
+## However that is hard, since environments like github actions or travis Ci
+## used detached heads and no control over the GIT clone process before getting
+## control to our build scripts. So we need to dance a lot. Oh shit ...
+
+# *** Try to figure out remote origin ***
+
+remote=`git config --get remote.origin.url`
+if [ "$remote" = "" ]; then
+	remote="unknown_remote"
+fi
+
+# *** Try to figure out branch ***
+
+if [ "$TRAVIS_BRANCH" = "" ]; then
+	if [ "$GITHUB_REF" = "" ]; then
+		branch=`git branch | awk 'BEGIN { s = "UNKNOWN" } $1 == "*" { s = $2 } END { print s }'`
+	else
+		branch="`echo $GITHUB_REF | awk -F/ '{ print $NF }'`"
+	fi
+else
+	branch="$TRAVIS_BRANCH"
+fi
+if [ "$branch" = "" ]; then
+	branch="unknown_branch"
+fi
+
+# *** Try to figure out commit ID ***
+
+if [ "$TRAVIS_COMMIT" = "" ]; then
+	commit=`git rev-parse HEAD`
+else
+	commit="$TRAVIS_COMMIT"
+fi
+if [ "$commit" = "" ]; then
+	commit="unknown_commit_id"
+fi
+
+# *** Print the result tripplet ***
+
+echo "$remote $branch $commit"
+
+# *** END ***
+
+exit 0

--- a/targets/mega65/io_mapper.c
+++ b/targets/mega65/io_mapper.c
@@ -50,35 +50,46 @@ int port_d607 = 0xFF;	// ugly hack to be able to read extra char row of C65
 	do { DEBUG("IO: NOT IMPLEMENTED write (emulator lacks feature), %s $%04X with data $%02X" NL, func, addr, data); \
 	return; } while(0)
 
-// Address of the "big" multiplier within the $D7XX area (byte only)
-#define BIGMULT_ADDR	0x70
-
-
 
 static void update_hw_multiplier ( void )
 {
-	D7XX[BIGMULT_ADDR + 3] &= 0x01;
-	D7XX[BIGMULT_ADDR + 6] &= 0x03;
-	D7XX[BIGMULT_ADDR + 7] =  0x00;
-	register Uint64 result = (Uint64)(
-		((Uint32) D7XX[BIGMULT_ADDR + 0]      ) |
-		((Uint32) D7XX[BIGMULT_ADDR + 1] <<  8) |
-		((Uint32) D7XX[BIGMULT_ADDR + 2] << 16) |
-		((Uint32) D7XX[BIGMULT_ADDR + 3] << 24)
-	) * (Uint64)(
-		((Uint32) D7XX[BIGMULT_ADDR + 4]      ) |
-		((Uint32) D7XX[BIGMULT_ADDR + 5] <<  8) |
-		((Uint32) D7XX[BIGMULT_ADDR + 6] << 16) |
-		((Uint32) D7XX[BIGMULT_ADDR + 7] << 24)
+	Uint32 input_a = (Uint64)(
+		((Uint32) D7XX[0x70]      ) |
+		((Uint32) D7XX[0x71] <<  8) |
+		((Uint32) D7XX[0x72] << 16) |
+		((Uint32) D7XX[0x73] << 24)
 	);
-	D7XX[BIGMULT_ADDR + 0x8] = (result      ) & 0xFF;
-	D7XX[BIGMULT_ADDR + 0x9] = (result >>  8) & 0xFF;
-	D7XX[BIGMULT_ADDR + 0xA] = (result >> 16) & 0xFF;
-	D7XX[BIGMULT_ADDR + 0xB] = (result >> 24) & 0xFF;
-	D7XX[BIGMULT_ADDR + 0xC] = (result >> 32) & 0xFF;
-	D7XX[BIGMULT_ADDR + 0xD] = (result >> 40) & 0xFF;
-	D7XX[BIGMULT_ADDR + 0xE] = 0;
-	D7XX[BIGMULT_ADDR + 0xF] = 0;
+	Uint32 input_b = (Uint64)(
+		((Uint32) D7XX[0x74]      ) |
+		((Uint32) D7XX[0x75] <<  8) |
+		((Uint32) D7XX[0x76] << 16) |
+		((Uint32) D7XX[0x77] << 24)
+	);
+	if (XEMU_LIKELY(input_b)) {
+		// We really don't want to divide by zero.
+		// It seems the policy on MEGA65 is not change the result
+		// registers AT ALL, if you try to divide by zero.
+		// So we only check if input_b != 0 and do the thing here then!
+		Uint32 div_quotient = input_a / input_b;
+		Uint32 div_reminder = input_a % input_b;
+		D7XX[0x68] = (div_reminder      ) & 0xFF;
+		D7XX[0x69] = (div_reminder >>  8) & 0xFF;
+		D7XX[0x6A] = (div_reminder >> 16) & 0xFF;
+		D7XX[0x6B] = (div_reminder >> 24) & 0xFF;
+		D7XX[0x6C] = (div_quotient      ) & 0xFF;
+		D7XX[0x6D] = (div_quotient >>  8) & 0xFF;
+		D7XX[0x6E] = (div_quotient >> 16) & 0xFF;
+		D7XX[0x6F] = (div_quotient >> 24) & 0xFF;
+	}
+	Uint64 mult_result = (Uint64)input_a * (Uint64)input_b;
+	D7XX[0x78] = (mult_result      ) & 0xFF;
+	D7XX[0x79] = (mult_result >>  8) & 0xFF;
+	D7XX[0x7A] = (mult_result >> 16) & 0xFF;
+	D7XX[0x7B] = (mult_result >> 24) & 0xFF;
+	D7XX[0x7C] = (mult_result >> 32) & 0xFF;
+	D7XX[0x7D] = (mult_result >> 40) & 0xFF;
+	D7XX[0x7E] = (mult_result >> 48) & 0xFF;
+	D7XX[0x7F] = (mult_result >> 56) & 0xFF;
 	bigmult_valid_result = 1;
 }
 
@@ -196,8 +207,11 @@ Uint8 io_read ( unsigned int addr )
 		case 0x37:	// $D700-$D7FF ~ M65 I/O mode
 			// FIXME: this is probably very bad! I guess DMA does not decode for every 16 addresses ... Proposed fix is here:
 			addr &= 0xFF;
-			if (addr < 16)
+			if (addr < 15)		// FIXME!!!! 0x0F was part of DMA reg array, but it seems now used by divisor busy stuff??
 				return dma_read_reg(addr & 0xF);
+			if (addr == 0x0F)
+				return 0;	// FIXME: D70F bit 7 = 32/32 bits divisor busy flag, bit 6 = 32*32 mult busy flag. We're never busy, so the zero. But the OTHER bits??? Any purpose of those??
+			// ;) FIXME this is LAZY not to decode if we need to update bigmult at all ;-P
 			if (XEMU_UNLIKELY(!bigmult_valid_result))
 				update_hw_multiplier();
 			return D7XX[addr];
@@ -421,7 +435,8 @@ void io_write ( unsigned int addr, Uint8 data )
 			addr &= 0xFF;
 			if (addr < 16)
 				dma_write_reg(addr & 0xF, data);
-			else if (XEMU_UNLIKELY((addr & 0xF0) == BIGMULT_ADDR))
+			//else if (XEMU_UNLIKELY((addr & 0xF0) == BIGMULT_ADDR))
+			else if (addr >= 0x68 && addr <= 0x7F)
 				bigmult_valid_result = 0;
 			D7XX[addr] = data;
 			return;

--- a/targets/mega65/mega65.c
+++ b/targets/mega65/mega65.c
@@ -367,7 +367,7 @@ static void mega65_init ( void )
 		fast_mhz = MEGA65_DEFAULT_FAST_CLOCK;
 	}
 	sprintf(fast_mhz_in_string, "%dMHz", fast_mhz);
-	cpu_cycles_per_scanline_for_fast_mode = 64 * fast_mhz;
+	cpu_cycles_per_scanline_for_fast_mode = 32 * fast_mhz;
 	DEBUGPRINT("SPEED: fast clock is set to %dMHz, %d CPU cycles per scanline." NL, fast_mhz, cpu_cycles_per_scanline_for_fast_mode);
 	cpu65_reset(); // reset CPU (though it fetches its reset vector, we don't use that on M65, but the KS hypervisor trap)
 	rom_protect = 0;

--- a/targets/mega65/mega65.h
+++ b/targets/mega65/mega65.h
@@ -44,9 +44,10 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
 
 // Needed CPU cycles for a (PAL) scanline for a given mode.
 // For "fast clock", it's calculated, see MEGA65_DEFAULT_FAST_CLOCK
-#define CPU_C65_CYCLES_PER_SCANLINE	227
-#define CPU_C128_CYCLES_PER_SCANLINE	128
-#define CPU_C64_CYCLES_PER_SCANLINE	64
+// FIXME: these values are hard-coded, but in reality these must be different for PAL and NTSC modes!!!!!
+#define CPU_C65_CYCLES_PER_SCANLINE	113
+#define CPU_C128_CYCLES_PER_SCANLINE	64
+#define CPU_C64_CYCLES_PER_SCANLINE	32
 
 #define SID_CYCLES_PER_SEC	1000000
 #define AUDIO_SAMPLE_FREQ	44100


### PR DESCRIPTION
32x32 bit multiplier is a MEGA65 change in design to have full 32x32 bit multiplier. Bitplane selection implements the possibility to set pair of 64K banks to select bitplane sources. These are needed to run a decent copy of Bit Shifter's new ROM, without these, the hmw branch cannot run it. These changes were requested by people would like to try Bit Shifter's nice new ROMs but with combined VIC-IV goodies emulated better.

Inject memptr fix: there was some pointer adjustment missing, thus using PRG injection (CLI `-prg` option, or the context menu load directly) though worked, it freaked out if someone tried to edit a basic program loaded this way because of lacking the proper basic setup with its memory pointers.

cpu speed bug: mega65.h (and also mega65.c with a multiplier) had constants how much CPU cycles it means to have a scanline. this is in essence sets the emulated CPU speed. Unfortunately it seems, in your fork these were not adjusted that you went from "vic-ii" style logical to physical raster, thus cpu has become twice as fast than should be in every mode (this 1MHz mode become 2MHz, 3.5 is 7, 40 is 80 etc ... without noticing it as the display in the title surely shows 'what it should be). This change tries to fix this problem HOWEVER this is not the correct solution 100%, as these constants should be different in NTSC and PAL mode to be precise. But that's something would need some more major fix, since these are just constants at the moment and not depending on the video mode being PAL or NTSC unfortunately. Still even in NTSC mode it must be much more close to the true speed than before :)

There is even a "build related material" kind of commit. It consists of something you don't care too much I guess (discord webhook to announce builds from travis) but also various fixes which reported xemu branch incorrectly in the about window / console printouts. There are some minor mods in the configure mechanism as well. 